### PR TITLE
Add basic multi-player & imperfect info demo

### DIFF
--- a/examples/three_player_demo.py
+++ b/examples/three_player_demo.py
@@ -1,0 +1,25 @@
+import random
+from simple_games.three_player_card import ThreePlayerCardGame
+from mcts.imperfect_info_mcts import ImperfectInfoMCTS
+
+
+def main():
+    game = ThreePlayerCardGame()
+    full_state = game.getInitialState()
+    player = "A"
+    partial_state = game.getPartialState(full_state, player)
+
+    mcts = ImperfectInfoMCTS(game, perspective_player=player, num_iterations=100)
+    best_action = mcts.search(partial_state)
+    print("Recommended action for", player, ":", best_action)
+
+    state = game.applyAction(full_state, best_action)
+    while not game.isTerminal(state):
+        p = game.getCurrentPlayer(state)
+        legal = game.getLegalActions(state)
+        state = game.applyAction(state, random.choice(legal))
+    print("Game outcome:", game.getGameOutcome(state))
+
+
+if __name__ == "__main__":
+    main()

--- a/mcts/__init__.py
+++ b/mcts/__init__.py
@@ -1,4 +1,5 @@
 from .Mcts import MCTS
 from .single_perspective import SinglePerspectiveMCTS
+from .imperfect_info_mcts import ImperfectInfoMCTS
 
-__all__ = ["MCTS", "SinglePerspectiveMCTS"]
+__all__ = ["MCTS", "SinglePerspectiveMCTS", "ImperfectInfoMCTS"]

--- a/mcts/imperfect_info_mcts.py
+++ b/mcts/imperfect_info_mcts.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from .single_perspective import SinglePerspectiveMCTS
+
+
+class ImperfectInfoMCTS(SinglePerspectiveMCTS):
+    """Na\xefve determinization MCTS for games with hidden information."""
+
+    def __init__(self, game, perspective_player, *, determinization_fn=None, **kwargs):
+        super().__init__(game, perspective_player, **kwargs)
+        self.determinization_fn = determinization_fn or getattr(game, "sample_determinization", None)
+
+    def search(self, root_state, draw_callback=None):
+        if self.determinization_fn is not None:
+            determinized = self.determinization_fn(root_state, self.perspective_player)
+        else:
+            determinized = root_state
+        return super().search(determinized, draw_callback)

--- a/simple_games/three_player_card.py
+++ b/simple_games/three_player_card.py
@@ -1,0 +1,100 @@
+import random
+
+class ThreePlayerCardGame:
+    """Simple 3-player card swapping game with hidden information."""
+
+    PLAYERS = ["A", "B", "C"]
+    DECK_CARDS = [1, 2, 3, 4, 5]
+
+    def getInitialState(self):
+        deck = self.DECK_CARDS[:]
+        random.shuffle(deck)
+        cards = {p: deck.pop() for p in self.PLAYERS}
+        return {"deck": deck, "cards": cards, "current_index": 0}
+
+    def copyState(self, state):
+        return {
+            "deck": state["deck"][:],
+            "cards": state["cards"].copy(),
+            "current_index": state["current_index"],
+        }
+
+    def getCurrentPlayer(self, state):
+        return self.PLAYERS[state["current_index"]]
+
+    def getLegalActions(self, state):
+        if state["current_index"] >= len(self.PLAYERS):
+            return []
+        return ["keep", "swap"]
+
+    def applyAction(self, state, action):
+        new_state = self.copyState(state)
+        if state["current_index"] >= len(self.PLAYERS):
+            return new_state
+        player = self.getCurrentPlayer(state)
+        if action == "swap" and new_state["deck"]:
+            new_card = random.choice(new_state["deck"])
+            new_state["deck"].remove(new_card)
+            new_state["deck"].append(new_state["cards"][player])
+            new_state["cards"][player] = new_card
+        new_state["current_index"] += 1
+        return new_state
+
+    def getGameOutcome(self, state):
+        if state["current_index"] < len(self.PLAYERS):
+            return None
+        cards = state["cards"]
+        best = max(cards.values())
+        winners = [p for p, c in cards.items() if c == best]
+        if len(winners) == 1:
+            return winners[0]
+        return "Draw"
+
+    def isTerminal(self, state):
+        return self.getGameOutcome(state) is not None
+
+    def getPartialState(self, state, player):
+        partial = self.copyState(state)
+        for p in self.PLAYERS:
+            if p != player:
+                partial["cards"][p] = None
+        return partial
+
+    def sample_determinization(self, partial_state, player):
+        known = partial_state["cards"][player]
+        deck_pool = self.DECK_CARDS[:]
+        deck_pool.remove(known)
+        random.shuffle(deck_pool)
+        cards = {player: known}
+        for p in self.PLAYERS:
+            if p == player:
+                continue
+            cards[p] = deck_pool.pop()
+        deck = deck_pool
+        return {"deck": deck, "cards": cards, "current_index": partial_state["current_index"]}
+
+    def simulateRandomPlayout(self, state, perspectivePlayer, max_depth=10, eval_func=None, weights=None):
+        temp = self.copyState(state)
+        depth = 0
+        while not self.isTerminal(temp) and depth < max_depth:
+            player = self.getCurrentPlayer(temp)
+            legal = self.getLegalActions(temp)
+            action = random.choice(legal)
+            temp = self.applyAction(temp, action)
+            depth += 1
+        outcome = self.getGameOutcome(temp)
+        if outcome == perspectivePlayer:
+            return 1.0
+        elif outcome == "Draw" or outcome is None:
+            return 0.0
+        else:
+            return -1.0
+
+    def evaluateState(self, perspectivePlayer, state, weights=None):
+        outcome = self.getGameOutcome(state)
+        if outcome == perspectivePlayer:
+            return 1.0
+        elif outcome == "Draw" or outcome is None:
+            return 0.0
+        else:
+            return -1.0

--- a/tests/test_c4_zero_advanced.py
+++ b/tests/test_c4_zero_advanced.py
@@ -2,6 +2,11 @@ import os
 import tempfile
 import unittest
 
+try:
+    import pygame  # noqa: F401
+except Exception:  # pragma: no cover - skip if pygame missing
+    raise unittest.SkipTest("pygame not available")
+
 import examples.c4_zero_advanced as adv
 
 if adv.torch is None:  # pragma: no cover - skip if torch missing


### PR DESCRIPTION
## Summary
- extend MCTS package with `ImperfectInfoMCTS` for simple determinization-based play
- add `ThreePlayerCardGame` example game with hidden cards
- expose the new MCTS in `mcts/__init__.py`
- update test for `c4_zero_advanced` to skip if pygame missing
- include demo script showing how to run the new game with the new MCTS

## Testing
- `python -m unittest discover tests`
- `PYTHONPATH=. python examples/three_player_demo.py`